### PR TITLE
Logo fixes

### DIFF
--- a/mate_rov.html
+++ b/mate_rov.html
@@ -6,7 +6,7 @@ stylesheets : [projects]
 ---
 <div class="topspace"></div>
 <div id="project">
-    <a href="http://www.nasa.gov/offices/education/centers/kennedy/technology/nasarmc.html" target="_blank"><img class="logo" src="res/mate_rov.png"/></a>
+    <a href="https://materovcompetition.org/" target="_blank"><img class="logo" src="res/MATE_ROV.png"/></a>
     <p class="hd">MATE ROV Competition</p>
     <div class="division"></div>
     <p class="info">


### PR DESCRIPTION
The logo now links to the ROV website instead of the NASA website and the logo image has the right name and exists